### PR TITLE
Fix release auto build

### DIFF
--- a/.github/workflows/build-steamdeck-flatpak.yml
+++ b/.github/workflows/build-steamdeck-flatpak.yml
@@ -34,6 +34,19 @@ jobs:
         ls -la .github/workflows/
         echo "Manifest file exists:"
         ls -la moonlight-steamdeck.yml || echo "Manifest file not found"
+        echo "Git status:"
+        git status || echo "Git status failed"
+        echo "Git log (last 5 commits):"
+        git log --oneline -5 || echo "Git log failed"
+    
+    - name: Validate manifest
+      run: |
+        echo "Validating Flatpak manifest..."
+        if ! flatpak-builder --dry-run --user moonlight-steamdeck.yml; then
+          echo "❌ Manifest validation failed"
+          exit 1
+        fi
+        echo "✅ Manifest validation passed"
     
     - name: Setup Flatpak
       uses: flatpak/flatpak-github-actions/flatpak-builder@v6
@@ -42,6 +55,7 @@ jobs:
         bundle: moonlight-steamdeck
         cache-key: flatpak-builder-moonlight-steamdeck-${{ hashFiles('moonlight-steamdeck.yml') }}
         verbose: true
+        fail-fast: true
     
     - name: Get version info
       id: version
@@ -123,9 +137,9 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: moonlight-steamdeck-${{ steps.version.outputs.version }}
-                  path: |
-            moonlight-steamdeck-${{ steps.version.outputs.version }}.flatpak
-            RELEASE_NOTES_${{ steps.version.outputs.version }}.md
+        path: |
+          moonlight-steamdeck-${{ steps.version.outputs.version }}.flatpak
+          RELEASE_NOTES_${{ steps.version.outputs.version }}.md
         retention-days: 30
     
     - name: Create Release (on tag)
@@ -133,7 +147,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          ${{ matrix.output }}-${{ steps.version.outputs.version }}.flatpak
+          moonlight-steamdeck-${{ steps.version.outputs.version }}.flatpak
           RELEASE_NOTES_${{ steps.version.outputs.version }}.md
         body_path: RELEASE_NOTES_${{ steps.version.outputs.version }}.md
         draft: false

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - cursor/build-flatpak-for-steam-deck-2dfa
+      - master
+      - main
 
 jobs:
   test-build:
@@ -27,6 +28,24 @@ jobs:
         echo "✅ Build test completed successfully!"
         echo "📦 Flatpak bundle created: moonlight-steamdeck-test.flatpak"
         echo "🎮 Ready for Steam Deck installation"
+        
+        # Check file size
+        if [ -f moonlight-steamdeck-test.flatpak ]; then
+          size=$(du -h moonlight-steamdeck-test.flatpak | cut -f1)
+          echo "📊 Bundle size: $size"
+        else
+          echo "❌ Bundle file not found!"
+          exit 1
+        fi
+        
+        # Validate bundle
+        echo "🔍 Validating Flatpak bundle..."
+        if flatpak build-bundle --list-contents moonlight-steamdeck-test.flatpak > /dev/null 2>&1; then
+          echo "✅ Bundle validation passed"
+        else
+          echo "❌ Bundle validation failed"
+          exit 1
+        fi
     
     - name: Upload test artifact
       uses: actions/upload-artifact@v4

--- a/moonlight-steamdeck.yml
+++ b/moonlight-steamdeck.yml
@@ -1,6 +1,6 @@
 app-id: com.moonlight_stream.Moonlight
 runtime: org.kde.Platform
-runtime-version: '6.4'
+runtime-version: '6.5'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Platform.GL.default
@@ -135,11 +135,10 @@ modules:
   - name: moonlight-desktop
     buildsystem: simple
     build-commands:
-      - install -D com.moonlight_stream.Moonlight.desktop /app/share/applications/
-      - install -D moonlight.svg /app/share/icons/hicolor/scalable/apps/
-      - install -D com.moonlight_stream.Moonlight.appdata.xml /app/share/metainfo/
+      - install -D app/deploy/linux/com.moonlight_stream.Moonlight.desktop /app/share/applications/
+      - install -D app/res/moonlight.svg /app/share/icons/hicolor/scalable/apps/
+      - install -D app/deploy/linux/com.moonlight_stream.Moonlight.appdata.xml /app/share/metainfo/
     sources:
-      - type: dir
-        path: app/deploy/linux
-      - type: file
-        path: app/res/moonlight.svg
+      - type: git
+        url: https://github.com/moonlight-stream/moonlight-qt.git
+        tag: v6.1.0

--- a/scripts/build-steamdeck-flatpak.sh
+++ b/scripts/build-steamdeck-flatpak.sh
@@ -81,7 +81,7 @@ setup_runtimes() {
     # Install required runtimes (skip if system bus unavailable)
     print_status "Installing required runtimes..."
     if [ -S /run/dbus/system_bus_socket ] 2>/dev/null; then
-        flatpak install --user org.freedesktop.Platform//23.08 org.freedesktop.Sdk//23.08 || true
+        flatpak install --user org.kde.Platform//6.5 org.kde.Sdk//6.5 || true
     else
         print_warning "System bus unavailable, skipping runtime installation"
         print_warning "This may cause build issues. Consider running in a proper desktop environment."


### PR DESCRIPTION
Fixes the release auto build process by correcting GitHub Actions workflow, Flatpak manifest, and build script configurations.

This PR resolves multiple issues preventing successful automatic Flatpak builds and releases for Steam Deck. It corrects file paths and indentation in GitHub Actions, updates Flatpak manifest to correctly source desktop integration files from `moonlight-qt` and use the latest runtime, and enhances the build script and test workflow for improved reliability and validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-08f250d5-20f9-4184-8ce5-c959755038ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-08f250d5-20f9-4184-8ce5-c959755038ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

