### PR TITLE
Fix appimage build and push

### DIFF
--- a/app/backend/computermanager.h
+++ b/app/backend/computermanager.h
@@ -295,5 +295,5 @@ private:
     bool m_NeedsDelayedFlush;
     
     // Auto-connection
-    QString m_LastUsedHostUuid;
+    mutable QString m_LastUsedHostUuid;
 };


### PR DESCRIPTION
Mark `m_LastUsedHostUuid` as mutable to fix a const correctness build error in `ComputerManager::getLastUsedHost()`.

---
<a href="https://cursor.com/background-agent?bcId=bc-126572b1-58e8-4616-9f0b-32e60651e22c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-126572b1-58e8-4616-9f0b-32e60651e22c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

